### PR TITLE
Add turva.dev and turva-llms-txt-validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ I'll help you convert the data into the markdown format you've started. I'll con
 - [Trail of Bits](https://www.trailofbits.com/llms.txt)
 - [Trigger.dev](https://trigger.dev/docs/llms.txt)
 - [Turso](https://docs.turso.tech/llms.txt)
+- [turva.dev](https://turva.dev/llms.txt)
 - [UnifyGTM](https://docs.unifygtm.com/llms.txt)
 - [Unkey](https://www.unkey.com/docs/llms.txt)
 - [Unstructured](https://docs.unstructured.io/llms.txt)
@@ -159,3 +160,4 @@ I'll help you convert the data into the markdown format you've started. I'll con
 - [llmstxtgenerator.org](https://llmstxtgenerator.org/)
 - [llms-generator](https://github.com/nfodor/llms-generator)
 - [starlight-llms-txt](https://delucis.github.io/starlight-llms-txt/)
+- [turva-llms-txt-validator](https://github.com/erekola/llms-txt-validator)


### PR DESCRIPTION
Adds turva.dev to In the Wild (signed llms.txt and llms-full.txt) and turva-llms-txt-validator to Tools: an MIT-licensed npm package and CLI that validates a site's /llms.txt structure with seven checks, each reported as pass, warn or fail, plus JSON output for CI. npm: https://www.npmjs.com/package/turva-llms-txt-validator